### PR TITLE
Remove deprecated requeststash/json logging

### DIFF
--- a/lib/lookout/rack/utils/log.rb
+++ b/lib/lookout/rack/utils/log.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'log4r'
 require 'singleton'
-require 'rack/requestash/log4r'
 require 'time'
 require 'configatron'
 
@@ -84,10 +83,6 @@ module Lookout::Rack::Utils
                                       :trunc => false})
       @logger.trace = true
       @outputter.formatter = LookoutFormatter
-
-      if ENV['RACK_ENV'] == 'production'
-        @outputter.formatter = Rack::Requestash::Log4r::Formatter
-      end
       @logger.outputters = @outputter
     end
 

--- a/lib/lookout/rack/utils/version.rb
+++ b/lib/lookout/rack/utils/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Utils
-      VERSION = "2.0.0"
+      VERSION = "3.0.0"
     end
   end
 end

--- a/lookout-rack-utils.gemspec
+++ b/lookout-rack-utils.gemspec
@@ -20,17 +20,17 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 2.0"
+  spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "timecop"
 
   spec.add_runtime_dependency "i18n"
 
-  spec.add_dependency "rack", '>= 1.5.0'
+  spec.add_dependency "rack", '~> 1.5.0'
   spec.add_dependency "rack-graphite", '~> 1.1'
-  spec.add_dependency "rack-requestash"
   spec.add_dependency "configatron", '~> 2.13'
   spec.add_dependency "log4r"
-  spec.add_dependency "lookout-statsd", '>= 0.7.0'
+  spec.add_dependency "lookout-statsd", '>= 0.7'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib/')
 require 'lookout/rack/utils'
 
 require 'rspec'
+require 'rspec/its'
 
 require 'rack/test'
 

--- a/spec/subroute_spec.rb
+++ b/spec/subroute_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe Lookout::Rack::Utils::Subroute, :type => :route do
   describe '#subroute' do
@@ -84,7 +85,7 @@ describe Lookout::Rack::Utils::Subroute, :type => :route do
         its(:status) { should be 201 }
 
         it 'should return expected output' do
-          expect(JSON.parse(subrouted.body)['deleted']).to be_true
+          expect(JSON.parse(subrouted.body)['deleted']).to be true
         end
       end
 
@@ -120,17 +121,17 @@ describe Lookout::Rack::Utils::Subroute, :type => :route do
     subject { SubrouteTestHelper.new.succeeded?(status) }
     context 'with status 200' do
       let(:status) { 200 }
-      it { should be_true }
+      it { should be true }
     end
 
     context 'with status 299' do
       let(:status) { 299 }
-      it { should be_true }
+      it { should be true }
     end
 
     context 'with a non-20x status' do
       let(:status) { 300 }
-      it { should be_false }
+      it { should be false }
     end
   end
 
@@ -138,17 +139,17 @@ describe Lookout::Rack::Utils::Subroute, :type => :route do
     subject { SubrouteTestHelper.new.failed?(status) }
     context 'with status 200' do
       let(:status) { 200 }
-      it { should be_false }
+      it { should be false }
     end
 
     context 'with status 299' do
       let(:status) { 299 }
-      it { should be_false }
+      it { should be false }
     end
 
     context 'with a non-20x status' do
       let(:status) { 300 }
-      it { should be_true }
+      it { should be true }
     end
   end
 end


### PR DESCRIPTION
Note:
- includes minor fixes to suppress rspec warnings
- pin down version of rack-1.5.x and rspec-2.x