### PR TITLE
Add unzipping functionality to Request module

### DIFF
--- a/lib/lookout/rack/utils/request.rb
+++ b/lib/lookout/rack/utils/request.rb
@@ -1,6 +1,10 @@
+require 'zlib'
+
 module Lookout::Rack::Utils
   module Request
     ILLEGAL_CHARS_REGEX = /[<>]/
+    HTTP_CONTENT_ENCODING_KEY = "HTTP_CONTENT_ENCODING"
+    CONTENT_ENCODING_GZIPPED = "gzip"
 
     # Return the raw, unprocessed request body
     #
@@ -11,11 +15,33 @@ module Lookout::Rack::Utils
       return request.body.read
     end
 
-    # Process and parse the request body as JSON
+    # Return the gunzipped but otherwise raw, unprocessed request body
     #
     # Will halt and create a a 400 status code if there is something wrong with
     # the body
     #
+    # @return  [String]
+    def gunzipped_body
+      body = raw_body
+      if request.env[HTTP_CONTENT_ENCODING_KEY] != CONTENT_ENCODING_GZIPPED
+        return body
+      else
+        begin
+          return gunzip(body)
+        rescue Zlib::Error
+          if defined?(Lookout::Rack::Utils::Log)
+            Lookout::Rack::Utils::Log.instance.warn "Unzipping error when decompressing request body (#{body})"
+          end
+          halt 400, "{}"
+        end
+      end
+    end
+
+    # Process and parse the request body as JSON
+    #
+    # Will halt and create a a 400 status code if there is something wrong with
+    # the body
+    #s
     def body_as_json
       body = raw_body
 
@@ -31,5 +57,24 @@ module Lookout::Rack::Utils
         halt 400, "{}"
       end
     end
+
+    private
+
+    # Decompresses data
+    #
+    # @raise [Zlib::Error] if malformed data is provided
+    # @return [String]
+    def gunzip(data)
+      # We set the window bits to MAX_WBITS + 32 to enable zlib and gzip decoding
+      # with automatic header detection.
+      zstream = Zlib::Inflate.new(Zlib::MAX_WBITS+32)
+      begin
+        decompressed = zstream.inflate(data)
+      ensure
+        zstream.close
+      end
+      decompressed
+    end
+
   end
 end

--- a/lib/lookout/rack/utils/request.rb
+++ b/lib/lookout/rack/utils/request.rb
@@ -3,8 +3,8 @@ require 'zlib'
 module Lookout::Rack::Utils
   module Request
     ILLEGAL_CHARS_REGEX = /[<>]/
-    HTTP_CONTENT_ENCODING_KEY = "HTTP_CONTENT_ENCODING"
-    CONTENT_ENCODING_GZIPPED = "gzip"
+    HTTP_CONTENT_ENCODING_KEY = "HTTP_CONTENT_ENCODING".freeze
+    CONTENT_ENCODING_GZIPPED = "gzip".freeze
 
     # Return the raw, unprocessed request body
     #
@@ -15,7 +15,7 @@ module Lookout::Rack::Utils
       return request.body.read
     end
 
-    # Return the gunzipped but otherwise raw, unprocessed request body
+    # Return the body, which is gunzipped only if the appropriate header is set on the request
     #
     # Will halt and create a a 400 status code if there is something wrong with
     # the body
@@ -41,7 +41,6 @@ module Lookout::Rack::Utils
     #
     # Will halt and create a a 400 status code if there is something wrong with
     # the body
-    #s
     def body_as_json
       body = raw_body
 

--- a/lib/lookout/rack/utils/version.rb
+++ b/lib/lookout/rack/utils/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Utils
-      VERSION = "3.0.2"
+      VERSION = "3.1.0"
     end
   end
 end

--- a/lib/lookout/rack/utils/version.rb
+++ b/lib/lookout/rack/utils/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Utils
-      VERSION = "3.0.1"
+      VERSION = "3.0.2"
     end
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'lib/lookout/rack/utils/request'
+require 'zlib'
+
+class TestHelper
+  attr_accessor :request
+
+  include Lookout::Rack::Utils::Request
+
+  def initialize
+  end
+end
+
+
+describe Lookout::Rack::Utils::Request do
+  let(:helper) { TestHelper.new }
+  let(:sample_data) {'i am groot'}
+  let(:zipped_sample_data){Zlib::Deflate.deflate(sample_data)}
+
+  describe '#gunzipped_body' do
+
+    before :each do
+      helper.request = Object.new
+      helper.request.stub(:env).and_return({'HTTP_CONTENT_ENCODING' => 'gzip'})
+      helper.request.stub(:body).and_return(double)
+      helper.request.body.stub(:rewind).and_return(double)
+    end
+
+    it 'should unzip data zipped data properly' do
+      helper.request.body.stub(:read).and_return(zipped_sample_data)
+      expect(helper.gunzipped_body).to eq(sample_data)
+    end
+
+    it 'should do nothing if encoding is not set' do
+      helper.request.stub(:env).and_return({})
+      helper.request.body.stub(:read).and_return(zipped_sample_data)
+      expect(helper.gunzipped_body).to eq(zipped_sample_data)
+    end
+
+    it 'should halt and throw and 400 when we have badly encoded data' do
+      helper.request.body.stub(:read).and_return(sample_data)
+      expect(helper).to receive(:halt).with(400, "{}")
+      helper.gunzipped_body
+    end
+  end
+
+end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'lib/lookout/rack/utils/request'
+require 'lookout/rack/utils/request'
 require 'zlib'
 
 class TestHelper

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -38,6 +38,7 @@ describe Lookout::Rack::Utils::Request do
     end
 
     it 'should halt and throw and 400 when we have badly encoded data' do
+      allow_any_instance_of(Lookout::Rack::Utils::Log).to receive(:warn)
       helper.request.body.stub(:read).and_return(sample_data)
       expect(helper).to receive(:halt).with(400, "{}")
       helper.gunzipped_body


### PR DESCRIPTION
Extending the Request module in the Utils that previously had only two methods :raw_body and :body_as_json and adding a third, :gunzipped_body. 
Created 3 test cases, 
a) positive test case (encoding -> gzip, body->zipped_data) -> unzipped data
b) positive test case (encoding -> nil, body->zipped_data) -> zipped data
c) negative test case (encoding -> gzip, body->unzipped_data) -> 400