### PR TITLE
Find common subdir between basedir and trace path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.rbc
+.ruby-gemset
+.ruby-version
 .bundle
 .config
 .yardoc

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -158,4 +158,31 @@ describe Lookout::Rack::Utils::Log::LookoutFormatter do
     end
 
   end
+
+  describe "#common_basedir" do
+    subject(:common_basedir) { formatter.common_basedir(path) }
+
+    context "with no common path" do
+      let(:path) { "/impossible/path" }
+
+      it "should return basedir" do
+        expect(subject).to eq basedir
+      end
+    end
+
+    context "with a partially shared path" do
+      let(:path) { File.expand_path(File.join(basedir, "..", "tmp", "foo.rb")) }
+
+      it "should return shared path" do
+        expect(subject).to eq File.expand_path(File.join(basedir, ".."))
+      end
+    end
+
+    context "with a fully shared path" do
+      let(:path) { File.expand_path(File.join(basedir, "tmp.rb")) }
+      it "should return full path" do
+        expect(subject).to eq basedir
+      end
+    end
+  end
 end


### PR DESCRIPTION
When this gem is packed into a war along with other gems and code (with
warbler), the gem is placed into a subdirectory matching how bundler
installed the gems. The current basedir computed by the gem doesn't
match anything, so all logs have the full path (which is really
long). So instead compute the longest common base directory the first
time anything is logged and use that.

This may not do the right thing in all cases, but I don't think it's any
worse than what's there right now.