### PR TITLE
Bump rack-graphite dependency

### DIFF
--- a/lookout-rack-utils.gemspec
+++ b/lookout-rack-utils.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "i18n"
 
   spec.add_dependency "rack", '~> 1.5'
-  spec.add_dependency "rack-graphite", '~> 1.1'
+  spec.add_dependency "rack-graphite", '~> 1.3'
   spec.add_dependency "configatron", '~> 2.13'
   spec.add_dependency "log4r"
   spec.add_dependency "lookout-statsd", '~> 3.0'


### PR DESCRIPTION
That gem didn't previously have a lookout-statsd version dependency, but
we need at least 1.3 for new lookout-statsd.