### PR TITLE
Use Statsd#time instead of #timing

### DIFF
--- a/lib/lookout/rack/utils/graphite.rb
+++ b/lib/lookout/rack/utils/graphite.rb
@@ -15,7 +15,8 @@ module Lookout::Rack::Utils
   # Use as:
   #   Lookout::Rack::Utils::Graphite.increment('device.associated')
   #   Lookout::Rack::Utils::Graphite.update_counter('device.associated', 5)
-  #   Lookout::Rack::Utils::Graphite.timing('device.associated') do
+  #   Lookout::Rack::Utils::Graphite.timing('device.associated', 3305)
+  #   Lookout::Rack::Utils::Graphite.time('device.associated') do
   #     # work
   #   end
   #

--- a/lib/lookout/rack/utils/version.rb
+++ b/lib/lookout/rack/utils/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Utils
-      VERSION = "3.6.0"
+      VERSION = "3.7.0"
     end
   end
 end

--- a/lookout-rack-utils.gemspec
+++ b/lookout-rack-utils.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack-graphite", '~> 1.3'
   spec.add_dependency "configatron", '~> 2.13'
   spec.add_dependency "log4r"
-  spec.add_dependency "lookout-statsd", '~> 3.0'
+  spec.add_dependency "lookout-statsd", '~> 3.1'
 end

--- a/spec/graphite_spec.rb
+++ b/spec/graphite_spec.rb
@@ -23,6 +23,7 @@ describe Lookout::Rack::Utils::Graphite do
       it { should respond_to :increment }
       it { should respond_to :decrement }
       it { should respond_to :timing }
+      it { should respond_to :time }
       it { should respond_to :update_counter }
     end
 
@@ -31,18 +32,18 @@ describe Lookout::Rack::Utils::Graphite do
       Lookout::Rack::Utils::Graphite.increment('device.associated')
     end
 
-    describe '#timing' do
+    describe '#time' do
       it 'should delegate the block to statsd' do
         expect { |block|
-          Lookout::Statsd.instance.should_receive(:timing).once.with('device.became_aware', &block)
-          Lookout::Rack::Utils::Graphite.timing('device.became_aware', &block)
+          Lookout::Statsd.instance.should_receive(:time).once.with('device.became_aware', &block)
+          Lookout::Rack::Utils::Graphite.time('device.became_aware', &block)
         }.to yield_control
       end
 
       it 'should delegate the sample rate and block to statsd' do
         expect { |block|
-          Lookout::Statsd.instance.should_receive(:timing).once.with('device.became_aware', 0.05, &block)
-          Lookout::Rack::Utils::Graphite.timing('device.became_aware', 0.05, &block)
+          Lookout::Statsd.instance.should_receive(:time).once.with('device.became_aware', 0.05, &block)
+          Lookout::Rack::Utils::Graphite.time('device.became_aware', 0.05, &block)
         }.to yield_control
       end
     end
@@ -52,12 +53,14 @@ describe Lookout::Rack::Utils::Graphite do
     let(:statsd_instance) { double('Statsd',
                                    :increment => true,
                                    :decrement => true,
+                                   :time => true,
                                    :timing => true,
                                    :update_counter => true) }
 
     context 'offers statsd methods' do
       it { should respond_to :increment }
       it { should respond_to :decrement }
+      it { should respond_to :time }
       it { should respond_to :timing }
       it { should respond_to :update_counter }
     end
@@ -67,18 +70,18 @@ describe Lookout::Rack::Utils::Graphite do
       Lookout::Rack::Utils::Graphite.increment('device.associated')
     end
 
-    describe '#timing' do
+    describe '#time' do
       it 'should delegate the block to statsd' do
         expect { |block|
-          expect(statsd_instance).to receive(:timing).once.with('device.became_aware', &block)
-          Lookout::Rack::Utils::Graphite.timing('device.became_aware', &block)
+          expect(statsd_instance).to receive(:time).once.with('device.became_aware', &block)
+          Lookout::Rack::Utils::Graphite.time('device.became_aware', &block)
         }.to yield_control
       end
 
       it 'should delegate the sample rate and block to statsd' do
         expect { |block|
-          expect(statsd_instance).to receive(:timing).once.with('device.became_aware', 0.05, &block)
-          Lookout::Rack::Utils::Graphite.timing('device.became_aware', 0.05, &block)
+          expect(statsd_instance).to receive(:time).once.with('device.became_aware', 0.05, &block)
+          Lookout::Rack::Utils::Graphite.time('device.became_aware', 0.05, &block)
         }.to yield_control
       end
     end


### PR DESCRIPTION
Lookout-statsd used #timing where other statsd's use #time, but
lookout-statsd now has #time as well, so use that for compatibility.