### PR TITLE
Add milliseconds to format of time for logs.

### DIFF
--- a/lib/lookout/rack/utils/log.rb
+++ b/lib/lookout/rack/utils/log.rb
@@ -79,7 +79,8 @@ module Lookout::Rack::Utils
       # @return [String] Formatted log message
       def format(event)
         filename = event_filename(event.tracer[1])
-        time = Time.now.utc.iso8601
+        # CCYY-MM-DDThh:mm:ss.sssTZD
+        time = Time.now.utc.iso8601 3
         return "#{Log4r::LNAMES[event.level]}: #{time}: #{filename}: #{event.data}\n"
       end
     end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -146,7 +146,8 @@ describe Lookout::Rack::Utils::Log::LookoutFormatter do
       # Level 3 is the Log4r "warn" level
       let(:level) { 3 }
       let(:data) { 'rspec' }
-      let(:timestamp) { Time.now.utc.iso8601 }
+      # use CCYY-MM-DDThh:mm:ss.sssTZD timestamp
+      let(:timestamp) { Time.now.utc.iso8601 3 }
 
       let(:event) do
         event = Log4r::LogEvent.new(level, logger, tracer, data)


### PR DESCRIPTION
Allows for more accurate log line timing to assist in performance analysis.
