### PR TITLE
Remove dependency on log4r

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/tmp
 test/version_tmp
 tmp
 log
+.rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source :rubygems
 
 # Specify your gem's dependencies in lookout-rack-utils.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ app:
 present, it will increment those stats whenever a log is written.
 
   ```ruby
-  configatron.project_name = 'My project name'
   configatron.logging do |l|
     l.enabled = true
     l.level = 'WARN'
     l.file = 'log/some_file.log'
   end
+
+  Lookout::Rack::Utils::Log.instance.debug "My Message"
   ```
 
 ### Lookout::Rack::Utils::Request

--- a/lib/lookout/rack/utils/log.rb
+++ b/lib/lookout/rack/utils/log.rb
@@ -1,144 +1,43 @@
 require 'rubygems'
-require 'log4r'
 require 'singleton'
 require 'time'
 require 'configatron'
 
 module Lookout::Rack::Utils
-  # Logging.  Logs to log/<project_name>.log with the format:
-  #
-  #   [Log Level]: [Timestamp (ISO-8601)]: [File:linenum]: [Log Message]
-  #
-  # Use through the helper:
-  #   log.warn 'This is my log message'
-  #
   class Log
     include Singleton
-    include Log4r
-
-    # Formatter that include the filename and relative path, and line number in
-    # output of the caller.
-    #
-    # Since all callers go through the methods defined in this class to log, we
-    # look at the second line of the tracer output, removing everything but the
-    # directories after the project directory.
-    #
-    class LookoutFormatter < Log4r::Formatter
-      # Return the project base directory for filtering to help with
-      # identifiying the filename and line number when formatting the log
-      # message
-      #
-      # @return [String] Base directory for the project
-      def basedir
-        @basedir ||= File.expand_path(File.join(File.dirname(__FILE__), ".."))
-      end
-
-      # Return the common base directory between this project and the
-      # given trace. If no common base directory is found, return
-      # basedir.
-      #
-      # This memoizes the result, which can be bad if the first log
-      # comes from an unusual place. However, in all current uses this
-      # is running from an unpacked jar/war and its vastly faster to
-      # memoize the result.
-      #
-      # @param [String] tracer A line from the LogEvent#tracer Array
-      # @return [String] Common base directory with the trace
-      def common_basedir(tracer)
-        return @common_basedir if @common_basedir
-
-        basedir_pieces = basedir.split(File::SEPARATOR)
-        trace_pieces = tracer.split(File::SEPARATOR)
-        i = 0
-        while basedir_pieces[i] == trace_pieces[i]
-          i += 1
-        end
-        # If there were no common directories (besides /), return our basedir
-        @common_basedir = (i <= 1) ? basedir : basedir_pieces[0...i].join(File::SEPARATOR)
-      end
-
-      # Return a trimmed version of the filename from where a LogEvent occurred
-      # @param [String] tracer A line from the LogEvent#tracer Array
-      # @return [String] Trimmed and parsed version of the file ane line number
-      def event_filename(tracer)
-        base = common_basedir(tracer)
-        parts = tracer.match(/#{base}\/(.*:[0-9]+).*:/)
-
-        # If we get no matches back, we're probably in a jar file in which case
-        # the format of the tracer is going to be abbreviated
-        if parts.nil?
-          parts = tracer.match(/(.*:[0-9]+).*:/)
-        end
-        return parts[-1] if parts
-      end
-
-      # Receive the LogEvent and pull out the log message and format it for
-      # display in the logs
-      #
-      # @param [Log4r::LogEvent] event
-      # @return [String] Formatted log message
-      def format(event)
-        filename = event_filename(event.tracer[1])
-        # CCYY-MM-DDThh:mm:ss.sssTZD
-        time = Time.now.utc.iso8601 3
-        return "#{Log4r::LNAMES[event.level]}: #{time}: #{filename}: #{event.data}\n"
-      end
-    end
-
-
-    attr_reader :outputter
 
     def initialize
-      logger_name = configatron.project_name.to_s.gsub(/\s*/, '_')
-      if logger_name.nil? || logger_name.empty?
-        logger_name = 'no_name_given'
-      end
-
-      @logger = Logger.new(logger_name)
+      file = configatron.logging.file
 
       if configatron.logging.enabled
-        index = Log4r::LNAMES.index(configatron.logging.level)
-        # if logger.level is not in LNAMES an exception will be thrown
-        @logger.level = index unless index.nil?
+        @logger = if file == 'stdout'
+          Logger.new($stdout)
+        else
+          Logger.new(file)
+        end
       else
-        @logger.level = Log4r::OFF
+        @logger = Logger.new(File::NULL)
       end
 
-      @outputter = build_outputter(logger_name)
-      @logger.trace = true
-      @outputter.formatter = LookoutFormatter
-      @logger.outputters = @outputter
+      @logger.level = Logger.const_get(configatron.logging.level)
     end
-
 
     [:debug, :info, :warn, :error, :fatal, :level].each do |method|
       define_method(method) do |*args, &block|
         if defined?(Lookout::Rack::Utils::Graphite)
           unless method == :level
-            Lookout::Rack::Utils::Graphite.increment("log.#{method}") unless (configatron.statsd.exclude_levels || []).include?(method)
+            unless (configatron.statsd.exclude_levels || []).include?(method)
+              Lookout::Rack::Utils::Graphite.increment("log.#{method}")
+            end
           end
         end
         @logger.send(method, *args, &block)
       end
-
-      # Returns true iff the current severity level allows for
-      # the printing of level messages.
-      allow_logging = "#{method}?".to_sym
-      define_method(allow_logging) do |*args|
-        @logger.send(allow_logging, *args)
-      end
     end
 
-    # Build and return the appropriate Outputter
-    def build_outputter(logger_name)
-      if configatron.logging.file =~ /^stdout$/i
-        StdoutOutputter.new("#{logger_name}stdout")
-      else
-        FileOutputter.new("#{logger_name}fileoutput",
-                          {:filename => configatron.logging.file,
-                           :trunc => false})
-      end
+    def method_missing(name, *args, &block)
+      @logger.public_send(name, *args, &block)
     end
-    private :build_outputter
   end
 end

--- a/lib/lookout/rack/utils/version.rb
+++ b/lib/lookout/rack/utils/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Utils
-      VERSION = "3.8.0"
+      VERSION = "4.0.0"
     end
   end
 end

--- a/lookout-rack-utils.gemspec
+++ b/lookout-rack-utils.gemspec
@@ -31,6 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", '~> 1.5'
   spec.add_dependency "rack-graphite", '~> 1.3'
   spec.add_dependency "configatron", '~> 2.13'
-  spec.add_dependency "log4r"
   spec.add_dependency "lookout-statsd", '~> 3.1'
 end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -10,6 +10,7 @@ describe Lookout::Rack::Utils::Log do
 
   before :each do
     configatron.logging.enabled = true
+    configatron.logging.level = "DEBUG"
     allow(configatron.logging).to receive(:file).and_return(filename)
   end
 
@@ -27,6 +28,17 @@ describe Lookout::Rack::Utils::Log do
     it 'should log a graphite stat' do
       Lookout::Rack::Utils::Graphite.should_receive(:increment).with('log.debug')
       log.debug log_message
+    end
+
+    context "with logging disabled" do
+      before :each do
+        configatron.logging.enabled = false
+      end
+
+      it "should not log anything" do
+        log.debug log_message
+        # kinda hard to test, but provides code coverage
+      end
     end
   end
 
@@ -66,124 +78,5 @@ describe Lookout::Rack::Utils::Log do
       end
     end
   end
-
-  # Private method but tested since we can't otherwise test configuration of the singleton
-  describe "#build_outputter" do
-    let(:logger_name) { "logger" }
-    subject(:build_outputter) { log.send(:build_outputter, logger_name)}
-
-    context "when logging to a file" do
-      let(:filename) { "foo.log" }
-      it "should use a FileOutputter" do
-        expect(subject).to be_a(Log4r::FileOutputter)
-      end
-    end
-
-    context "when logging to STDOUT" do
-      let(:filename) { "STDOUT" }
-      it "should use a StdoutOutputter" do
-        expect(subject).to be_a(Log4r::StdoutOutputter)
-      end
-    end
-  end
 end
 
-describe Lookout::Rack::Utils::Log::LookoutFormatter do
-  subject(:formatter) { described_class.new }
-  let(:logger) do
-    logger = double('Mock Logger')
-    logger.stub(:name).and_return('RSpec Logger')
-    logger.stub(:fullname).and_return('RSpec Logger')
-    logger
-  end
-  let(:project_name) { 'some_project' }
-  let(:basedir) { "/home/rspec/#{project_name}" }
-  let(:tracer) do
-    [
-        "#{basedir}/log.rb:63:in `warn'",
-        "#{basedir}/spec/log_spec.rb:9:in `block (2 levels) in <top (required)>'"
-    ]
-  end
-
-  before :all do
-    # The root logger creates the log levels, so making sure it's been
-    # created
-    Log4r::RootLogger.instance
-  end
-
-
-  before :each do
-    formatter.stub(:basedir).and_return(basedir)
-  end
-
-
-  describe '#event_filename' do
-    subject(:filename) { formatter.event_filename(tracer[1]) }
-
-    context 'with a normal MRI LogEvent' do
-      it { should eql('spec/log_spec.rb:9') }
-    end
-
-    # We have slightly different log formats under packaged .jar files
-    context 'with a LogEvent from a packaged .jar' do
-      let(:tracer) { [nil, "backend/metrics.rb:52:in `runloop'"] }
-      let(:basedir) { 'file:/home/user/source/projects/stuff.jar!/project' }
-
-      it { should eql('backend/metrics.rb:52') }
-    end
-  end
-
-  describe '#format' do
-    before :each do
-      Timecop.freeze
-    end
-
-    after :each do
-      Timecop.return
-    end
-
-    context 'with a valid LogEvent' do
-      # Level 3 is the Log4r "warn" level
-      let(:level) { 3 }
-      let(:data) { 'rspec' }
-      # use CCYY-MM-DDThh:mm:ss.sssTZD timestamp
-      let(:timestamp) { Time.now.utc.iso8601 3 }
-
-      let(:event) do
-        event = Log4r::LogEvent.new(level, logger, tracer, data)
-      end
-
-      it 'should be properly formatted' do
-        expect(formatter.format(event)).to eql("WARN: #{timestamp}: spec/log_spec.rb:9: #{data}\n")
-      end
-    end
-
-  end
-
-  describe "#common_basedir" do
-    subject(:common_basedir) { formatter.common_basedir(path) }
-
-    context "with no common path" do
-      let(:path) { "/impossible/path" }
-
-      it "should return basedir" do
-        expect(subject).to eq basedir
-      end
-    end
-
-    context "with a partially shared path" do
-      let(:path) { File.expand_path(File.join(basedir, "..", "tmp", "foo.rb")) }
-
-      it "should return shared path" do
-        expect(subject).to eq File.expand_path(File.join(basedir, ".."))
-      end
-    end
-
-    context "with a fully shared path" do
-      let(:path) { File.expand_path(File.join(basedir, "tmp.rb")) }
-      it "should return full path" do
-        expect(subject).to eq basedir
-      end
-    end
-  end
-end


### PR DESCRIPTION
Log4r hasn't been updated in 7 years. Replace this with the standard
ruby logger and let each projects setup its log format.